### PR TITLE
Link directly to desired workflow run attempt as opposed to summary for the given commit

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func main() {
 				field := []Field{
 					{
 						Title: "Actions URL",
-						Value: "<" + os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv("GITHUB_REPOSITORY") + "/commit/" + os.Getenv("GITHUB_SHA") + "/checks|" + os.Getenv("GITHUB_WORKFLOW") + ">",
+						Value: "<" + os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv("GITHUB_REPOSITORY") + "/actions/runs/" + os.Getenv("GITHUB_RUN_ID") + "/attempts/" + os.Getenv("GITHUB_RUN_ATTEMPT") + "|" + os.Getenv("GITHUB_WORKFLOW") + ">",
 						Short: true,
 					},
 				}
@@ -146,7 +146,7 @@ func main() {
 			},
 			{
 				Title: "Actions URL",
-				Value: "<" + os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv("GITHUB_REPOSITORY") + "/commit/" + os.Getenv("GITHUB_SHA") + "/checks|" + os.Getenv("GITHUB_WORKFLOW") + ">",
+				Value: "<" + os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv("GITHUB_REPOSITORY") + "/actions/runs/" + os.Getenv("GITHUB_RUN_ID") + "/attempts/" + os.Getenv("GITHUB_RUN_ATTEMPT") + "|" + os.Getenv("GITHUB_WORKFLOW") + ">",
 				Short: true,
 			},
 			{


### PR DESCRIPTION
We have started to add more and more workflows that run on each commit. This makes linking to the summary for the 
commit less helpful since the investigator for any message must click through multiple levels of links to get to the 
actual desired information. This change has the "Actions url" point directly to the currently running workflow attempt 
instead of the summary.
