### PR TITLE
Update the docker image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'This action will send a notification to Slack'
 author: 'rtCamp'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/rtcamp/action-slack-notify:v2.2.0'
+  image: 'docker://ghcr.io/thebrowsercompany/action-slack-notify:045ed46e033207f92d6e038b8a48be42d599242e'
 branding:
   icon: 'bell'
   color: 'yellow'


### PR DESCRIPTION
Since we changed the code we need to update the docker image that GitHub
actions will use. So do that.

```
; docker build .
[+] Building 30.2s (18/18) FINISHED
[...]
 => => writing image sha256:7dfcb5711c11c4a7dae4164c2f99117d04f99b3b8affa3af68fd992030ecddfb                                                                                                                                                                                               0.0s

; docker login ghcr.io
Username: amonshiz
Password:
Login Succeeded

; docker tag sha256:7dfcb5711c11c4a7dae4164c2f99117d04f99b3b8affa3af68fd992030ecddfb ghcr.io/thebrowsercompany/action-slack-notify:045ed46e033207f92d6e038b8a48be42d599242e

; docker push ghcr.io/thebrowsercompany/action-slack-notify:045ed46e033207f92d6e038b8a48be42d599242e
The push refers to repository [ghcr.io/thebrowsercompany/action-slack-notify]
ab9347ec8b06: Pushed
848a1f5c8d73: Pushed
353431ec86e4: Pushed
62f98c5d6397: Pushed
947a18bc05d0: Pushed
0b9674e8a9c7: Pushed
5216338b40a7: Pushed
045ed46e033207f92d6e038b8a48be42d599242e: digest: sha256:f1cb141fbbc86068270147252b813151b267578fbb85fd289c5ee205d5089ffe size: 1786
```